### PR TITLE
Improve docs

### DIFF
--- a/docs/coins.rst
+++ b/docs/coins.rst
@@ -25,7 +25,7 @@ Issue own coin is as simple as filling a form with given fields:
 .. figure:: assets/coin-minter.png
     :width: 300px
 
-- **Coin name** - Name of a coin. Arbitrary string.
+- **Coin name** - Name of a coin. Arbitrary string up to 64 letters length.
 - **Coin symbol** - Symbol of a coin. Must be unique, alphabetic, uppercase, 3 to 10 letters length.
 - **Initial supply** - Amount of coins to issue. Issued coins will be available to sender account.
 - **Initial reserve** - Initial reserve in base coin.

--- a/docs/running-in-production.rst
+++ b/docs/running-in-production.rst
@@ -6,7 +6,7 @@ DOS Exposure and Mitigation
 
 Validators are supposed to setup `Sentry Node Architecture
 <https://blog.cosmos.network/tendermint-explained-bringing-bft-based-pos-to-the-public-blockchain-domain-f22e274a0fdb>`__
-to prevent Denial-of-service attacks. You can read more about it `here
+to prevent Denial-of-service attacks. `Read more about it
 <https://github.com/tendermint/aib-data/blob/develop/medium/TendermintBFT.md>`__.
 
 P2P
@@ -40,9 +40,9 @@ wrong.
 Other useful endpoints include mentioned earlier `/status`, `/net_info` and
 `/validators`.
 
-We have a small tool, called tm-monitor, which outputs information from the
-endpoints above plus some statistics. The tool can be found `here
-<https://github.com/tendermint/tools/tree/master/tm-monitor>`__.
+We have a small tool, called `tm-monitor
+<https://github.com/tendermint/tools/tree/master/tm-monitor>`__, which outputs information from the
+endpoints above plus some statistics.
 
 
 Monitoring Minter
@@ -90,8 +90,8 @@ Operating Systems
 ~~~~~~~~~~~~~~~~~
 
 Tendermint and Minter can be compiled for a wide range of operating systems thanks to Go
-language (the list of $OS/$ARCH pairs can be found `here
-<https://golang.org/doc/install/source#environment>`__).
+language. `List of $OS/$ARCH pairs
+<https://golang.org/doc/install/source#environment>`__.
 
 While we do not favor any operation system, more secure and stable Linux server
 distributions (like Centos) should be preferred over desktop operation systems

--- a/docs/transactions.rst
+++ b/docs/transactions.rst
@@ -150,7 +150,7 @@ Transaction for creating new coin in a system.
         ConstantReserveRatio uint
     }
 
-| **Name** - Name of a coin. Arbitrary string.
+| **Name** - Name of a coin. Arbitrary string up to 64 letters length.
 | **Symbol** - Symbol of a coin. Must be unique, alphabetic, uppercase, 3 to 10 symbols length.
 | **InitialAmount** - Amount of coins to issue. Issued coins will be available to sender account.
 | **InitialReserve** - Initial reserve in BIP's.


### PR DESCRIPTION
Changes to docs:
- Move links inside the text, instead of separate sentence. E.g. "Minter. See `here`." -> "`Minter`."
- Specify CoinName limit
