### PR TITLE
github workflow fix #4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       API_RUN_PORT: 8841
       SECRET_DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
       SECRET_DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+      SECRET_DOCKER_HUB_REPO: ${{ secrets.DOCKER_HUB_REPO }}
       DOCKER_IMAGE: minter
     runs-on: ubuntu-latest
     steps:
@@ -24,11 +25,13 @@ jobs:
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
-
+          
+      # if secret DOCKER_HUB_REPO is not set DOCKER_HUB_USER will be used instead of REPO  
+      # otherwise secrets are empty and repo "testbuild" will be used
       - name: Set envs
         run: |
           echo ::set-env name=VERSION::$(awk -F\" '/Version =/ { print $2; exit }' < version/version.go)
-          echo ::set-env name=DOCKER_REPO::$(if [[ "$SECRET_DOCKER_HUB_USER" == "" ]]; then echo "prbuild"; else echo "$SECRET_DOCKER_HUB_USER"; fi;)
+          echo ::set-env name=DOCKER_REPO::$(if [[ "$SECRET_DOCKER_HUB_REPO" == "" ]]; then if [[ "$SECRET_DOCKER_HUB_USER" == "" ]]; then echo "testbuild"; else echo "$SECRET_DOCKER_HUB_USER"; fi; else echo "$SECRET_DOCKER_HUB_REPO"; fi)
 
       - name: Docker build
         run: docker build -t $DOCKER_REPO/$DOCKER_IMAGE:$VERSION .
@@ -38,7 +41,7 @@ jobs:
 
       - name: Check container is still running
         run: |
-          echo ::set-env name=RUN_TEST_RESULT::$(sleep $CONTAINER_TIMEOUT_SEC && if [[ $(docker inspect -f "{{.State.Running}}" $CONTAINER_NAME 2> /dev/null) == true ]]; then echo OK; else echo FAIL; fi;)
+          echo ::set-env name=RUN_TEST_RESULT::$(sleep $CONTAINER_TIMEOUT_SEC && if [[ $(docker inspect -f "{{.State.Running}}" $CONTAINER_NAME 2> /dev/null) == true ]]; then echo OK; else echo FAIL; fi)
 
       - name: Check api is available by HTTP (response code is 200)
         run: |
@@ -54,7 +57,7 @@ jobs:
         if: env.RUN_TEST_RESULT == 'FAIL' || env.API_TEST_RESULT == 'FAIL'
 
       - name: Docker login
-        run: echo "$SECRET_DOCKER_HUB_PASSWORD" | docker login -u $DOCKER_REPO --password-stdin
+        run: echo "$SECRET_DOCKER_HUB_PASSWORD" | docker login -u $SECRET_DOCKER_HUB_USER --password-stdin
         if: github.ref == 'refs/heads/master'
 
       - name: Docker push versioned image


### PR DESCRIPTION
Now we can use secret `DOCKER_HUB_REPO`  as repository name for `docker push`
If this secret is not set, secret with name `DOCKER_HUB_USER` will be used